### PR TITLE
fix(Futter Plugin): when `onAttachedToEngine` is called more than once, all streams breaks

### DIFF
--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/TwilioConversationsPlugin.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/TwilioConversationsPlugin.kt
@@ -23,6 +23,7 @@ class TwilioConversationsPlugin : FlutterPlugin {
         @Suppress("unused")
         @JvmStatic
         lateinit var instance: TwilioConversationsPlugin
+        private var initialized = false
 
         // Flutter > Host APIs
         @JvmStatic
@@ -77,6 +78,14 @@ class TwilioConversationsPlugin : FlutterPlugin {
     }
 
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        if (initialized) {
+            Log.d(LOG_TAG, "TwilioConversationsPlugin.onAttachedToEngine: already initialized")
+            return
+        } else {
+            Log.d(LOG_TAG, "TwilioConversationsPlugin.onAttachedToEngine")
+        }
+
+        initialized = true
         instance = this
         messenger = flutterPluginBinding.binaryMessenger
         applicationContext = flutterPluginBinding.applicationContext


### PR DESCRIPTION
Fixes https://github.com/la-haus/app-adviser-flutter/issues/124

The current setup breaks if `onAttachedToEngine` is called more than once.

> **Note**
> This happens after calling `FirebaseMessaging.onBackgroundMessage(` from Firebase Messaging Console.

This is the real issue:
- https://github.com/firebase/flutterfire/issues/9689

# Current
If, for some reason, the flutter engine gets reinitialized all streams with updates stops emitting

# Expected
It works fine