### PR TITLE
feat(Resilience): do not crash all if something goes wrong internally

### DIFF
--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeCallbackListener.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeCallbackListener.kt
@@ -1,0 +1,16 @@
+package twilio.flutter.twilio_conversations.listeners
+
+import com.twilio.conversations.CallbackListener
+import com.twilio.util.ErrorInfo
+
+interface SafeCallbackListener<T> : CallbackListener<T> {
+    override fun onSuccess(result: T) {
+        try {
+            onSafeSuccess(result)
+        } catch (e: Exception) {
+            onError(ErrorInfo(-1, e.message ?: "Unknown error"))
+        }
+    }
+
+    fun onSafeSuccess(item: T)
+}

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeCallbackListener.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeCallbackListener.kt
@@ -3,11 +3,39 @@ package twilio.flutter.twilio_conversations.listeners
 import com.twilio.conversations.CallbackListener
 import com.twilio.util.ErrorInfo
 
+interface SafeNullableCallbackListener<T> : CallbackListener<T?> {
+    override fun onSuccess(result: T?) {
+        try {
+            if (result != null) {
+                onSafeSuccess(result)
+            } else {
+                onError(ErrorInfo(-1, "Got a null result"))
+            }
+        } catch (e: Exception) {
+            onError(ErrorInfo(-1, e.message ?: "Unknown error"))
+        } catch (e: Throwable) {
+            onError(ErrorInfo(-1, e.message ?: "Unknown error"))
+        } catch (e: NullPointerException) {
+            onError(ErrorInfo(-1, e.message ?: "Unknown error"))
+        }
+    }
+
+    fun onSafeSuccess(item: T?)
+}
+
 interface SafeCallbackListener<T> : CallbackListener<T> {
     override fun onSuccess(result: T) {
         try {
-            onSafeSuccess(result)
+            if (result != null) {
+                onSafeSuccess(result)
+            } else {
+                onError(ErrorInfo(-1, "Got a null result"))
+            }
         } catch (e: Exception) {
+            onError(ErrorInfo(-1, e.message ?: "Unknown error"))
+        } catch (e: Throwable) {
+            onError(ErrorInfo(-1, e.message ?: "Unknown error"))
+        } catch (e: NullPointerException) {
             onError(ErrorInfo(-1, e.message ?: "Unknown error"))
         }
     }

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeStatusListener.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeStatusListener.kt
@@ -10,6 +10,10 @@ interface SafeStatusListener : StatusListener {
         } catch (e: Exception) {
             val errorInfo = ErrorInfo(-1, e.message ?: "Unknown error")
             onError(errorInfo)
+        } catch (e: Throwable) {
+            onError(ErrorInfo(-1, e.message ?: "Unknown error"))
+        } catch (e: NullPointerException) {
+            onError(ErrorInfo(-1, e.message ?: "Unknown error"))
         }
     }
 

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeStatusListener.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeStatusListener.kt
@@ -1,0 +1,17 @@
+package twilio.flutter.twilio_conversations.listeners
+
+import com.twilio.conversations.StatusListener
+import com.twilio.util.ErrorInfo
+
+interface SafeStatusListener : StatusListener {
+    override fun onSuccess() {
+        try {
+            onSafeSuccess()
+        } catch (e: Exception) {
+            val errorInfo = ErrorInfo(-1, e.message ?: "Unknown error")
+            onError(errorInfo)
+        }
+    }
+
+    fun onSafeSuccess()
+}

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ConversationClientMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ConversationClientMethods.kt
@@ -1,10 +1,8 @@
 package twilio.flutter.twilio_conversations.methods
 
-import com.twilio.conversations.CallbackListener
 import com.twilio.conversations.Conversation
 import com.twilio.conversations.ConversationsClient
 import com.twilio.util.ErrorInfo
-import com.twilio.conversations.StatusListener
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
@@ -15,14 +13,16 @@ import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedException
 import twilio.flutter.twilio_conversations.exceptions.MissingParameterException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
+import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class ConversationClientMethods : Api.ConversationClientApi {
     private val TAG = "ConversationClientMethods"
 
     override fun updateToken(token: String, result: Api.Result<Void>) {
         debug("updateToken")
-        TwilioConversationsPlugin.client?.updateToken(token, object : StatusListener {
-            override fun onSuccess() {
+        TwilioConversationsPlugin.client?.updateToken(token, object : SafeStatusListener {
+            override fun onSafeSuccess() {
                 debug("updateToken => onSuccess")
                 result.success(null)
             }
@@ -47,15 +47,15 @@ class ConversationClientMethods : Api.ConversationClientApi {
         debug("createConversation")
         try {
             TwilioConversationsPlugin.client?.createConversation(friendlyName, object :
-                CallbackListener<Conversation?> {
-                override fun onSuccess(conversation: Conversation?) {
-                    if (conversation == null) {
+                SafeCallbackListener<Conversation?> {
+                override fun onSafeSuccess(item: Conversation?) {
+                    if (item == null) {
                         debug("createConversation => onError: Conversation null")
                         result.error(RuntimeException("Error creating conversation: Conversation null"))
                         return
                     }
                     debug("createConversation => onSuccess")
-                    val conversationMap = Mapper.conversationToPigeon(conversation)
+                    val conversationMap = Mapper.conversationToPigeon(item)
                     result.success(conversationMap)
                 }
 
@@ -80,7 +80,8 @@ class ConversationClientMethods : Api.ConversationClientApi {
 
                 val convoStatuses = myConversations?.map { it.synchronizationStatus }
                 convoStatuses?.forEach {
-                    conversationsSynchronized = (conversationsSynchronized && (it == Conversation.SynchronizationStatus.ALL))
+                    conversationsSynchronized =
+                        (conversationsSynchronized && (it == Conversation.SynchronizationStatus.ALL))
                 }
 
                 delay(100)
@@ -102,17 +103,19 @@ class ConversationClientMethods : Api.ConversationClientApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         debug("getConversations => conversationSidOrUniqueName: $conversationSidOrUniqueName")
-        client.getConversation(conversationSidOrUniqueName, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                debug("getConversations => onSuccess")
-                result.success(Mapper.conversationToPigeon(conversation))
-            }
+        client.getConversation(
+            conversationSidOrUniqueName,
+            object : SafeCallbackListener<Conversation?> {
+                override fun onSafeSuccess(item: Conversation?) {
+                    debug("getConversations => onSuccess")
+                    result.success(Mapper.conversationToPigeon(item))
+                }
 
-            override fun onError(errorInfo: ErrorInfo) {
-                debug("getConversations => onError: $errorInfo")
-                result.error(TwilioException(errorInfo.code, errorInfo.message))
-            }
-        })
+                override fun onError(errorInfo: ErrorInfo) {
+                    debug("getConversations => onError: $errorInfo")
+                    result.error(TwilioException(errorInfo.code, errorInfo.message))
+                }
+            })
     }
 
     override fun getMyUser(result: Api.Result<Api.UserData>) {
@@ -127,36 +130,58 @@ class ConversationClientMethods : Api.ConversationClientApi {
         val token: String = tokenData.token
             ?: return result.error(MissingParameterException("The parameter 'token' was not provided"))
 
-        TwilioConversationsPlugin.client?.registerFCMToken(ConversationsClient.FCMToken(token), object : StatusListener {
-            override fun onSuccess() {
-                TwilioConversationsPlugin.flutterClientApi.registered { }
-                result.success(null)
-            }
+        TwilioConversationsPlugin.client?.registerFCMToken(
+            ConversationsClient.FCMToken(token),
+            object : SafeStatusListener {
+                override fun onSafeSuccess() {
+                    TwilioConversationsPlugin.flutterClientApi.registered { }
+                    result.success(null)
+                }
 
-            override fun onError(errorInfo: ErrorInfo) {
-                super.onError(errorInfo)
-                TwilioConversationsPlugin.flutterClientApi.registrationFailed(Mapper.errorInfoToPigeon(errorInfo)) { }
-                result.error(TwilioException(errorInfo.code, "Failed to register for FCM notifications: ${errorInfo.message}"))
-            }
-        })
+                override fun onError(errorInfo: ErrorInfo) {
+                    super.onError(errorInfo)
+                    TwilioConversationsPlugin.flutterClientApi.registrationFailed(
+                        Mapper.errorInfoToPigeon(
+                            errorInfo
+                        )
+                    ) { }
+                    result.error(
+                        TwilioException(
+                            errorInfo.code,
+                            "Failed to register for FCM notifications: ${errorInfo.message}"
+                        )
+                    )
+                }
+            })
     }
 
     override fun unregisterForNotification(tokenData: Api.TokenData, result: Api.Result<Void>) {
         val token: String = tokenData.token
             ?: return result.error(MissingParameterException("The parameter 'token' was not provided"))
 
-        TwilioConversationsPlugin.client?.unregisterFCMToken(ConversationsClient.FCMToken(token), object : StatusListener {
-            override fun onSuccess() {
-                TwilioConversationsPlugin.flutterClientApi.deregistered { }
-                result.success(null)
-            }
+        TwilioConversationsPlugin.client?.unregisterFCMToken(
+            ConversationsClient.FCMToken(token),
+            object : SafeStatusListener {
+                override fun onSafeSuccess() {
+                    TwilioConversationsPlugin.flutterClientApi.deregistered { }
+                    result.success(null)
+                }
 
-            override fun onError(errorInfo: ErrorInfo) {
-                super.onError(errorInfo)
-                TwilioConversationsPlugin.flutterClientApi.deregistrationFailed(Mapper.errorInfoToPigeon(errorInfo)) { }
-                result.error(TwilioException(errorInfo.code, "Failed to register for FCM notifications: ${errorInfo.message}"))
-            }
-        })
+                override fun onError(errorInfo: ErrorInfo) {
+                    super.onError(errorInfo)
+                    TwilioConversationsPlugin.flutterClientApi.deregistrationFailed(
+                        Mapper.errorInfoToPigeon(
+                            errorInfo
+                        )
+                    ) { }
+                    result.error(
+                        TwilioException(
+                            errorInfo.code,
+                            "Failed to register for FCM notifications: ${errorInfo.message}"
+                        )
+                    )
+                }
+            })
     }
 
     private fun disposeListeners() {

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ConversationClientMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ConversationClientMethods.kt
@@ -14,6 +14,7 @@ import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedExcept
 import twilio.flutter.twilio_conversations.exceptions.MissingParameterException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
 import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeNullableCallbackListener
 import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class ConversationClientMethods : Api.ConversationClientApi {
@@ -47,7 +48,7 @@ class ConversationClientMethods : Api.ConversationClientApi {
         debug("createConversation")
         try {
             TwilioConversationsPlugin.client?.createConversation(friendlyName, object :
-                SafeCallbackListener<Conversation?> {
+                SafeNullableCallbackListener<Conversation> {
                 override fun onSafeSuccess(item: Conversation?) {
                     if (item == null) {
                         debug("createConversation => onError: Conversation null")
@@ -105,7 +106,7 @@ class ConversationClientMethods : Api.ConversationClientApi {
         debug("getConversations => conversationSidOrUniqueName: $conversationSidOrUniqueName")
         client.getConversation(
             conversationSidOrUniqueName,
-            object : SafeCallbackListener<Conversation?> {
+            object : SafeNullableCallbackListener<Conversation> {
                 override fun onSafeSuccess(item: Conversation?) {
                     debug("getConversations => onSuccess")
                     result.success(Mapper.conversationToPigeon(item))

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ConversationMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ConversationMethods.kt
@@ -17,6 +17,8 @@ import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.MissingParameterException
 import twilio.flutter.twilio_conversations.exceptions.NotFoundException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
+import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class ConversationMethods : Api.ConversationApi {
     private val TAG = "ConversationMethods"
@@ -28,10 +30,10 @@ class ConversationMethods : Api.ConversationApi {
 
         try {
             client.getConversation(conversationSid, object :
-                CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.join(object : StatusListener {
-                        override fun onSuccess() {
+                SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.join(object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("join => onSuccess")
                             result.success(null)
                         }
@@ -59,10 +61,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.leave(object : StatusListener {
-                        override fun onSuccess() {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.leave(object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("leave => onSuccess")
                             result.success(null)
                         }
@@ -89,10 +91,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.destroy(object : StatusListener {
-                        override fun onSuccess() {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.destroy(object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("destroy => onSuccess")
                             result.success(null)
                         }
@@ -120,10 +122,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
                     debug("typing => onSuccess")
-                    conversation.typing()
+                    item.typing()
                     result.success(null)
                 }
 
@@ -147,10 +149,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
                     GlobalScope.launch {
-                        val message = conversation.sendMessage {
+                        val message = item.sendMessage {
                             this.body = options.body
 
                             val attributes = options.attributes
@@ -235,10 +237,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.addParticipantByIdentity(identity, Attributes(), object : StatusListener {
-                        override fun onSuccess() {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.addParticipantByIdentity(identity, Attributes(), object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("addParticipantByIdentity => onSuccess")
                             result.success(true)
                         }
@@ -270,13 +272,13 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    val participant = conversation.getParticipantBySid(participantSid)
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    val participant = item.getParticipantBySid(participantSid)
                         ?: return result.error(NotFoundException("Participant $participantSid not found."))
 
-                    conversation.removeParticipant(participant, object : StatusListener {
-                        override fun onSuccess() {
+                    item.removeParticipant(participant, object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("removeParticipant => onSuccess")
                             result.success(true)
                         }
@@ -308,10 +310,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.removeParticipantByIdentity(identity, object : StatusListener {
-                        override fun onSuccess() {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.removeParticipantByIdentity(identity, object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("removeParticipantByIdentity => onSuccess")
                             result.success(true)
                         }
@@ -342,9 +344,9 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                val participant = conversation.getParticipantByIdentity(identity)
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                val participant = item.getParticipantByIdentity(identity)
                     ?: return result.error(NotFoundException("No participant found with identity $identity"))
                 debug("getParticipantByIdentity => onSuccess")
                 val participantData = Mapper.participantToPigeon(participant)
@@ -367,9 +369,9 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                val participant = conversation.getParticipantBySid(participantSid)
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                val participant = item.getParticipantBySid(participantSid)
                     ?: return result.error(NotFoundException("No participant found with sid $participantSid"))
                 debug("getParticipantBySid => onSuccess")
                 val participantData = Mapper.participantToPigeon(participant)
@@ -391,10 +393,10 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
                 debug("getParticipantsList => onSuccess")
-                val participantsListData = Mapper.participantListToPigeon(conversation.participantsList)
+                val participantsListData = Mapper.participantListToPigeon(item.participantsList)
                 result.success(participantsListData.toMutableList())
             }
 
@@ -411,14 +413,14 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
                     debug("getMessagesCount => onSuccess")
-                    conversation.getMessagesCount(object : CallbackListener<Long> {
-                        override fun onSuccess(messageCount: Long) {
-                            debug("getMessagesCount => onSuccess: $messageCount")
+                    item.getMessagesCount(object : SafeCallbackListener<Long> {
+                        override fun onSafeSuccess(item: Long) {
+                            debug("getMessagesCount => onSuccess: $item")
                             val count = Api.MessageCount()
-                            count.count = messageCount
+                            count.count = item
                             result.success(count)
                         }
 
@@ -445,12 +447,12 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.getUnreadMessagesCount(object : CallbackListener<Long?> {
-                        override fun onSuccess(count: Long?) {
-                            debug("getUnreadMessagesCount => onSuccess: $count")
-                            result.success(count ?: 0)
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.getUnreadMessagesCount(object : SafeCallbackListener<Long> {
+                        override fun onSafeSuccess(item: Long) {
+                            debug("getUnreadMessagesCount => onSuccess: $item")
+                            result.success(item ?: 0)
                         }
 
                         override fun onError(errorInfo: ErrorInfo) {
@@ -479,21 +481,23 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.advanceLastReadMessageIndex(lastReadMessageIndex, object : CallbackListener<Long> {
-                    override fun onSuccess(count: Long) {
-                        debug("advanceLastReadMessageIndex => onSuccess")
-                        val unreadMessages = Api.MessageCount()
-                        unreadMessages.count = count
-                        result.success(unreadMessages)
-                    }
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                item.advanceLastReadMessageIndex(
+                    lastReadMessageIndex,
+                    object : SafeCallbackListener<Long> {
+                        override fun onSafeSuccess(item: Long) {
+                            debug("advanceLastReadMessageIndex => onSuccess")
+                            val unreadMessages = Api.MessageCount()
+                            unreadMessages.count = item
+                            result.success(unreadMessages)
+                        }
 
-                    override fun onError(errorInfo: ErrorInfo) {
-                        debug("advanceLastReadMessageIndex => onError: $errorInfo")
-                        result.error(TwilioException(errorInfo.code, errorInfo.message))
-                    }
-                })
+                        override fun onError(errorInfo: ErrorInfo) {
+                            debug("advanceLastReadMessageIndex => onError: $errorInfo")
+                            result.error(TwilioException(errorInfo.code, errorInfo.message))
+                        }
+                    })
             }
 
             override fun onError(errorInfo: ErrorInfo) {
@@ -512,13 +516,13 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.setLastReadMessageIndex(lastReadMessageIndex, object : CallbackListener<Long> {
-                    override fun onSuccess(count: Long) {
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                item.setLastReadMessageIndex(lastReadMessageIndex, object : SafeCallbackListener<Long> {
+                    override fun onSafeSuccess(item: Long) {
                         debug("setLastReadMessageIndex => onSuccess")
                         val unreadMessages = Api.MessageCount()
-                        unreadMessages.count = count
+                        unreadMessages.count = item
                         result.success(unreadMessages)
                     }
 
@@ -544,13 +548,13 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.setAllMessagesRead(object : CallbackListener<Long> {
-                    override fun onSuccess(count: Long) {
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                item.setAllMessagesRead(object : SafeCallbackListener<Long> {
+                    override fun onSafeSuccess(item: Long) {
                         debug("setAllMessagesRead => onSuccess")
                         val unreadMessages = Api.MessageCount()
-                        unreadMessages.count = count
+                        unreadMessages.count = item
                         result.success(unreadMessages)
                     }
 
@@ -576,13 +580,13 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.setAllMessagesUnread(object : CallbackListener<Long> {
-                    override fun onSuccess(count: Long?) {
-                        debug("setAllMessagesUnread => onSuccess: $count")
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                item.setAllMessagesUnread(object : SafeCallbackListener<Long> {
+                    override fun onSafeSuccess(item: Long) {
+                        debug("setAllMessagesUnread => onSuccess: $item")
                         val unreadMessages = Api.MessageCount()
-                        unreadMessages.count = count
+                        unreadMessages.count = item
                         result.success(unreadMessages)
                     }
 
@@ -606,13 +610,13 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
                     debug("getParticipantsCount => onSuccess")
-                    conversation.getParticipantsCount(object : CallbackListener<Long> {
-                        override fun onSuccess(messageCount: Long) {
-                            debug("getParticipantsCount => onSuccess: $messageCount")
-                            result.success(messageCount)
+                    item.getParticipantsCount(object : SafeCallbackListener<Long> {
+                        override fun onSafeSuccess(item: Long) {
+                            debug("getParticipantsCount => onSuccess: $item")
+                            result.success(item)
                         }
 
                         override fun onError(errorInfo: ErrorInfo) {
@@ -643,10 +647,10 @@ class ConversationMethods : Api.ConversationApi {
         val conversationAttributes = Mapper.pigeonToAttributes(attributes)
             ?: return result.error(ConversionException("Could not convert $attributes to valid Attributes"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.setAttributes(conversationAttributes, object : StatusListener {
-                    override fun onSuccess() {
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                item.setAttributes(conversationAttributes, object : SafeStatusListener {
+                    override fun onSafeSuccess() {
                         debug("setAttributes => onSuccess")
                         result.success(null)
                     }
@@ -674,12 +678,14 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.getMessageByIndex(messageIndex, object : CallbackListener<Message> {
-                    override fun onSuccess(message: Message) {
-                        conversation.removeMessage(message, object : StatusListener {
-                            override fun onSuccess() {
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                val conversation = item
+
+                conversation.getMessageByIndex(messageIndex, object : SafeCallbackListener<Message> {
+                    override fun onSafeSuccess(item: Message) {
+                        conversation.removeMessage(item, object : SafeStatusListener {
+                            override fun onSafeSuccess() {
                                 debug("removeMessage => onSuccess")
                                 result.success(true)
                             }
@@ -715,20 +721,23 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.getMessagesAfter(index, count.toInt(), object : CallbackListener<List<Message>> {
-                    override fun onSuccess(messages: List<Message>) {
-                        debug("getMessagesAfter => onSuccess")
-                        val messagesMap = messages.map { Mapper.messageToPigeon(it) }
-                        result.success(messagesMap.toMutableList())
-                    }
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                item.getMessagesAfter(
+                    index,
+                    count.toInt(),
+                    object : SafeCallbackListener<List<Message>> {
+                        override fun onSafeSuccess(item: List<Message>) {
+                            debug("getMessagesAfter => onSuccess")
+                            val messagesMap = item.map { Mapper.messageToPigeon(it) }
+                            result.success(messagesMap.toMutableList())
+                        }
 
-                    override fun onError(errorInfo: ErrorInfo) {
-                        debug("getMessagesAfter => onError: $errorInfo")
-                        result.error(TwilioException(errorInfo.code, errorInfo.message))
-                    }
-                })
+                        override fun onError(errorInfo: ErrorInfo) {
+                            debug("getMessagesAfter => onError: $errorInfo")
+                            result.error(TwilioException(errorInfo.code, errorInfo.message))
+                        }
+                    })
             }
 
             override fun onError(errorInfo: ErrorInfo) {
@@ -749,12 +758,12 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.getMessagesBefore(index, count.toInt(), object : CallbackListener<List<Message>> {
-                    override fun onSuccess(messages: List<Message>) {
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                item.getMessagesBefore(index, count.toInt(), object : SafeCallbackListener<List<Message>> {
+                    override fun onSafeSuccess(item: List<Message>) {
                         debug("getMessagesBefore => onSuccess")
-                        val messagesMap = messages.map { Mapper.messageToPigeon(it) }
+                        val messagesMap = item.map { Mapper.messageToPigeon(it) }
                         result.success(messagesMap.toMutableList())
                     }
 
@@ -782,18 +791,18 @@ class ConversationMethods : Api.ConversationApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                conversation.getMessageByIndex(messageIndex, object : CallbackListener<Message> {
-                    override fun onSuccess(message: Message) {
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                item.getMessageByIndex(messageIndex, object : SafeCallbackListener<Message> {
+                    override fun onSafeSuccess(item: Message) {
                         // Android SDK seems to think it's fine to return a different message
                         // if one with the given `messageIndex` does not exist. iOS throws
                         // an exception as one might expect.
                         // Therefore, we do some validation here on the Android side and throw
                         // an exception in order to achieve behaviour that is consistent across platforms.
-                        if (message.messageIndex == messageIndex) {
+                        if (item.messageIndex == messageIndex) {
                             debug("getMessageByIndex => onSuccess")
-                            result.success(Mapper.messageToPigeon(message))
+                            result.success(Mapper.messageToPigeon(item))
                         } else {
                             debug("getMessageByIndex => onError: No message found with messageIndex: $messageIndex")
                             result.error(NotFoundException("No message found with messageIndex: $messageIndex"))
@@ -824,14 +833,13 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation?) {
-                    conversation?.getLastMessages(count.toInt(), object : CallbackListener<List<Message>> {
-                        override fun
-                                onSuccess(messages: List<Message>) {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.getLastMessages(count.toInt(), object : SafeCallbackListener<List<Message>> {
+                        override fun onSafeSuccess(item: List<Message>) {
                             debug("getLastMessages => onSuccess")
 
-                            val messagesMap = messages.map { Mapper.messageToPigeon(it) }
+                            val messagesMap = item.map { Mapper.messageToPigeon(it) }
                             result.success(messagesMap.toMutableList())
                         }
 
@@ -864,10 +872,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.setFriendlyName(friendlyName, object : StatusListener {
-                        override fun onSuccess() {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.setFriendlyName(friendlyName, object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("setFriendlyName => onSuccess")
                             result.success(null)
                         }
@@ -902,10 +910,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ConversionException("Unknown notification level $notificationLevel."))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.setNotificationLevel(level, object : StatusListener {
-                        override fun onSuccess() {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.setNotificationLevel(level, object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("setNotificationLevel => onSuccess")
                             result.success(null)
                         }
@@ -937,10 +945,10 @@ class ConversationMethods : Api.ConversationApi {
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
         try {
-            client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-                override fun onSuccess(conversation: Conversation) {
-                    conversation.setUniqueName(uniqueName, object : StatusListener {
-                        override fun onSuccess() {
+            client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+                override fun onSafeSuccess(item: Conversation) {
+                    item.setUniqueName(uniqueName, object : SafeStatusListener {
+                        override fun onSafeSuccess() {
                             debug("setUniqueName => onSuccess")
                             result.success(null)
                         }

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ConversationMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ConversationMethods.kt
@@ -1,10 +1,7 @@
 import com.twilio.conversations.Attributes
-import com.twilio.conversations.CallbackListener
 import com.twilio.conversations.Conversation
 import com.twilio.util.ErrorInfo
 import com.twilio.conversations.Message
-import com.twilio.conversations.StatusListener
-import com.twilio.conversations.extensions.addListener
 import com.twilio.conversations.extensions.sendMessage
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -14,10 +11,10 @@ import twilio.flutter.twilio_conversations.Mapper
 import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedException
 import twilio.flutter.twilio_conversations.exceptions.ConversionException
-import twilio.flutter.twilio_conversations.exceptions.MissingParameterException
 import twilio.flutter.twilio_conversations.exceptions.NotFoundException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
 import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeNullableCallbackListener
 import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class ConversationMethods : Api.ConversationApi {
@@ -449,8 +446,8 @@ class ConversationMethods : Api.ConversationApi {
         try {
             client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
                 override fun onSafeSuccess(item: Conversation) {
-                    item.getUnreadMessagesCount(object : SafeCallbackListener<Long> {
-                        override fun onSafeSuccess(item: Long) {
+                    item.getUnreadMessagesCount(object : SafeNullableCallbackListener<Long> {
+                        override fun onSafeSuccess(item: Long?) {
                             debug("getUnreadMessagesCount => onSuccess: $item")
                             result.success(item ?: 0)
                         }

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessageMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessageMethods.kt
@@ -13,7 +13,7 @@ import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.NotFoundException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
 import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
-import twilio.flutter.twilio_conversations.listeners.SafeNullableCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class MessageMethods : Api.MessageApi {
     private val TAG = "MessageMethods"

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessageMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/MessageMethods.kt
@@ -2,8 +2,6 @@ package twilio.flutter.twilio_conversations.methods
 
 import com.twilio.conversations.*
 import com.twilio.util.ErrorInfo
-import com.twilio.conversations.extensions.getTemporaryContentUrl
-import com.twilio.conversations.extensions.getTemporaryContentUrlsForMedia
 import com.twilio.conversations.extensions.updateMessageBody
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -15,7 +13,7 @@ import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.NotFoundException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
 import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
-import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
+import twilio.flutter.twilio_conversations.listeners.SafeNullableCallbackListener
 
 class MessageMethods : Api.MessageApi {
     private val TAG = "MessageMethods"

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ParticipantMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ParticipantMethods.kt
@@ -9,8 +9,6 @@ import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedExcept
 import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.NotFoundException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
-import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
-import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class ParticipantMethods : Api.ParticipantApi {
     private val TAG = "ParticipantMethods"

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ParticipantMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ParticipantMethods.kt
@@ -1,9 +1,7 @@
 package twilio.flutter.twilio_conversations.methods
 
-import com.twilio.conversations.CallbackListener
 import com.twilio.conversations.Conversation
 import com.twilio.util.ErrorInfo
-import com.twilio.conversations.StatusListener
 import twilio.flutter.twilio_conversations.Api
 import twilio.flutter.twilio_conversations.Mapper
 import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
@@ -11,6 +9,8 @@ import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedExcept
 import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.NotFoundException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
+import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class ParticipantMethods : Api.ParticipantApi {
     private val TAG = "ParticipantMethods"
@@ -24,9 +24,9 @@ class ParticipantMethods : Api.ParticipantApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                val participant = conversation.getParticipantBySid(participantSid)
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                val participant = item.getParticipantBySid(participantSid)
                     ?: return result.error(NotFoundException("No participant found with SID: $participantSid"))
 
                 participant.getAndSubscribeUser {
@@ -54,12 +54,12 @@ class ParticipantMethods : Api.ParticipantApi {
         val participantAttributes = Mapper.pigeonToAttributes(attributes)
             ?: return result.error(ConversionException("Could not convert $attributes to valid Attributes"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                val participant = conversation.getParticipantBySid(participantSid)
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                val participant = item.getParticipantBySid(participantSid)
                     ?: return result.error(NotFoundException("No participant found with SID: $participantSid"))
-                participant.setAttributes(participantAttributes, object : StatusListener {
-                    override fun onSuccess() {
+                participant.setAttributes(participantAttributes, object : SafeStatusListener {
+                    override fun onSafeSuccess() {
                         debug("setAttributes => onSuccess")
                         result.success(null)
                     }
@@ -87,12 +87,12 @@ class ParticipantMethods : Api.ParticipantApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getConversation(conversationSid, object : CallbackListener<Conversation> {
-            override fun onSuccess(conversation: Conversation) {
-                val participant = conversation.getParticipantBySid(participantSid)
+        client.getConversation(conversationSid, object : SafeCallbackListener<Conversation> {
+            override fun onSafeSuccess(item: Conversation) {
+                val participant = item.getParticipantBySid(participantSid)
                     ?: return result.error(NotFoundException("No participant found with SID: $participantSid"))
-                participant.remove(object : StatusListener {
-                    override fun onSuccess() {
+                participant.remove(object : SafeStatusListener {
+                    override fun onSafeSuccess() {
                         debug("remove => onSuccess")
                         result.success(null)
                     }

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ParticipantMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/ParticipantMethods.kt
@@ -9,6 +9,8 @@ import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedExcept
 import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.NotFoundException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
+import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class ParticipantMethods : Api.ParticipantApi {
     private val TAG = "ParticipantMethods"

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/PluginMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/PluginMethods.kt
@@ -8,6 +8,7 @@ import twilio.flutter.twilio_conversations.Mapper
 import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
 import twilio.flutter.twilio_conversations.listeners.ClientListener
+import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
 
 class PluginMethods : Api.PluginApi {
     private val TAG = "PluginMethods"
@@ -30,13 +31,13 @@ class PluginMethods : Api.PluginApi {
             .createProperties()
 
         ConversationsClient.create(TwilioConversationsPlugin.applicationContext, jwtToken, props, object :
-            CallbackListener<ConversationsClient> {
-            override fun onSuccess(conversationsClient: ConversationsClient) {
-                debug("create => onSuccess - myIdentity: '${conversationsClient.myUser?.identity ?: "unknown"}'")
-                TwilioConversationsPlugin.client = conversationsClient
+            SafeCallbackListener<ConversationsClient> {
+            override fun onSafeSuccess(item: ConversationsClient) {
+                debug("create => onSuccess - myIdentity: '${item.myUser?.identity ?: "unknown"}'")
+                TwilioConversationsPlugin.client = item
                 TwilioConversationsPlugin.clientListener = ClientListener()
-                conversationsClient.addListener(TwilioConversationsPlugin.clientListener!!)
-                val clientMap = Mapper.conversationsClientToPigeon(conversationsClient)
+                item.addListener(TwilioConversationsPlugin.clientListener!!)
+                val clientMap = Mapper.conversationsClientToPigeon(item)
                 result.success(clientMap)
             }
 

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/PluginMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/PluginMethods.kt
@@ -1,6 +1,5 @@
 package twilio.flutter.twilio_conversations.methods
 
-import com.twilio.conversations.CallbackListener
 import com.twilio.conversations.ConversationsClient
 import com.twilio.util.ErrorInfo
 import twilio.flutter.twilio_conversations.Api
@@ -8,7 +7,6 @@ import twilio.flutter.twilio_conversations.Mapper
 import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
 import twilio.flutter.twilio_conversations.listeners.ClientListener
-import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
 
 class PluginMethods : Api.PluginApi {
     private val TAG = "PluginMethods"

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/PluginMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/PluginMethods.kt
@@ -7,6 +7,7 @@ import twilio.flutter.twilio_conversations.Mapper
 import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
 import twilio.flutter.twilio_conversations.listeners.ClientListener
+import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
 
 class PluginMethods : Api.PluginApi {
     private val TAG = "PluginMethods"

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/UserMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/UserMethods.kt
@@ -8,6 +8,8 @@ import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedException
 import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
+import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class UserMethods : Api.UserApi {
     private val TAG = "UserMethods"

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/UserMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/UserMethods.kt
@@ -1,8 +1,6 @@
 package twilio.flutter.twilio_conversations.methods
 
-import com.twilio.conversations.CallbackListener
 import com.twilio.util.ErrorInfo
-import com.twilio.conversations.StatusListener
 import com.twilio.conversations.User
 import twilio.flutter.twilio_conversations.Api
 import twilio.flutter.twilio_conversations.Mapper
@@ -10,6 +8,8 @@ import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedException
 import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
+import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
+import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class UserMethods : Api.UserApi {
     private val TAG = "UserMethods"
@@ -23,10 +23,10 @@ class UserMethods : Api.UserApi {
         val client = TwilioConversationsPlugin.client
             ?: return result.error(ClientNotInitializedException("Client is not initialized"))
 
-        client.getAndSubscribeUser(identity, object : CallbackListener<User> {
-            override fun onSuccess(user: User) {
-                user.setFriendlyName(friendlyName, object : StatusListener {
-                    override fun onSuccess() {
+        client.getAndSubscribeUser(identity, object : SafeCallbackListener<User> {
+            override fun onSafeSuccess(item: User) {
+                item.setFriendlyName(friendlyName, object : SafeStatusListener {
+                    override fun onSafeSuccess() {
                         debug("setFriendlyName => onSuccess")
                         result.success(null)
                     }
@@ -56,10 +56,10 @@ class UserMethods : Api.UserApi {
         val userAttributes = Mapper.pigeonToAttributes(attributes)
             ?: return result.error(ConversionException("Could not convert $attributes to valid Attributes"))
 
-        client.getAndSubscribeUser(identity, object : CallbackListener<User> {
-            override fun onSuccess(user: User) {
-                user.setAttributes(userAttributes, object : StatusListener {
-                    override fun onSuccess() {
+        client.getAndSubscribeUser(identity, object : SafeCallbackListener<User> {
+            override fun onSafeSuccess(item: User) {
+                item.setAttributes(userAttributes, object : SafeStatusListener {
+                    override fun onSafeSuccess() {
                         debug("setAttributes => onSuccess")
                         result.success(null)
                     }

--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/UserMethods.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/methods/UserMethods.kt
@@ -8,8 +8,6 @@ import twilio.flutter.twilio_conversations.TwilioConversationsPlugin
 import twilio.flutter.twilio_conversations.exceptions.ClientNotInitializedException
 import twilio.flutter.twilio_conversations.exceptions.ConversionException
 import twilio.flutter.twilio_conversations.exceptions.TwilioException
-import twilio.flutter.twilio_conversations.listeners.SafeCallbackListener
-import twilio.flutter.twilio_conversations.listeners.SafeStatusListener
 
 class UserMethods : Api.UserApi {
     private val TAG = "UserMethods"

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,17 @@
-org.gradle.jvmargs=-Xmx1536M
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Thu Apr 13 16:14:33 COT 2023
+android.enableR8=true
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true


### PR DESCRIPTION
Fixes:
- https://github.com/la-haus/app-adviser-flutter/issues/427
- https://github.com/la-haus/app-adviser-flutter/issues/279

# Current
When something goes wrong inside any subscribed listener on any Twilio SDK method, the process crash causing the app that uses it to crash also and report ARN errors.

# Expected
If something goes wrong, call `onError`  with the error and do not crash