### PR TITLE
fix(Conversation): remove logic of null result in `SafeCallbackListener`

### DIFF
--- a/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeCallbackListener.kt
+++ b/android/src/main/kotlin/twilio/flutter/twilio_conversations/listeners/SafeCallbackListener.kt
@@ -6,11 +6,7 @@ import com.twilio.util.ErrorInfo
 interface SafeNullableCallbackListener<T> : CallbackListener<T?> {
     override fun onSuccess(result: T?) {
         try {
-            if (result != null) {
-                onSafeSuccess(result)
-            } else {
-                onError(ErrorInfo(-1, "Got a null result"))
-            }
+            onSafeSuccess(result)
         } catch (e: Exception) {
             onError(ErrorInfo(-1, e.message ?: "Unknown error"))
         } catch (e: Throwable) {


### PR DESCRIPTION
Close #[442](https://github.com/la-haus/app-adviser-flutter/issues/442)

# Current behavior
Gives error each time we query the unread messages counter

# Expected behavior
Error is fixed